### PR TITLE
Restore missing `get_url`

### DIFF
--- a/interface/models.py
+++ b/interface/models.py
@@ -110,6 +110,9 @@ class Submission(models.Model):
     def state_label(self):
         return self.STATE_CHOICES[self.state]
 
+    def get_url(self):
+        return storage.get_link(f'{self.id}.zip')
+
     def evaluate(self):
         callback = (f"submission/{self.id}/done?"
                     f"token={str(self.generate_jwt(), encoding='latin1')}")


### PR DESCRIPTION
```
  File "/opt/interface/interface/models.py", line 121, in evaluate
    options['env']['archive'] = self.get_url()
AttributeError: 'Submission' object has no attribute 'get_url'
```