### PR TITLE
adding ignore-pipfile and silencing output

### DIFF
--- a/ci/provision-acs-interface.sh
+++ b/ci/provision-acs-interface.sh
@@ -6,7 +6,7 @@ sudo pip3 install pipenv
 
 
 cd /vagrant
-pipenv install --ignore-pipfile &> /dev/null
+pipenv install --ignore-pipfile 2> /dev/null
 mkdir -p data
 
 container=$(docker ps -f name=minio -aq)

--- a/ci/provision-acs-interface.sh
+++ b/ci/provision-acs-interface.sh
@@ -6,7 +6,7 @@ sudo pip3 install pipenv
 
 
 cd /vagrant
-pipenv install
+pipenv install --ignore-pipfile &> /dev/null
 mkdir -p data
 
 container=$(docker ps -f name=minio -aq)


### PR DESCRIPTION
PR for #78 

Added `--ignore-pipfile` and silenced pipenv output. 

Based on [comments on a closed bug](https://github.com/pypa/pipenv/issues/1920
) `pipenv` doesn't support a `--quite` option, so just redirecting the output to `/dev/null` will keep vagrant pretty. However failures may go unnoticed. Perhaps send output to a file instead and on successful completion delete the file? Let me know if you want me to do this. 

https://github.com/pypa/pipenv/issues/1920
