### PR TITLE
Fix the minio urlparse bug from python 3.7.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7-stretch
+FROM python:3.7.5-stretch
 
 ENV PATH="/root/.local/bin:${PATH}"
 WORKDIR /opt/interface


### PR DESCRIPTION
The minio Python library [was broken](https://github.com/minio/minio-py/issues/835) by Python 3.7.6 so let's use 3.7.5 until they fix it.