### PR TITLE
Zip.testZip() fail case

### DIFF
--- a/interface/views.py
+++ b/interface/views.py
@@ -84,6 +84,9 @@ def upload(request, course_code, assignment_code):
             except CorruptZipFile:
                 messages.error(request, 'The archive is corrupt')
 
+            except ValueError:
+                messages.error(request, 'The archive is corrupt')
+
             except BadZipFile:
                 messages.error(request, 'File is not a valid zip archive')
 

--- a/interface/views.py
+++ b/interface/views.py
@@ -81,10 +81,7 @@ def upload(request, course_code, assignment_code):
                     f'Please wait {e.wait_t}s between submissions',
                 )
 
-            except CorruptZipFile:
-                messages.error(request, 'The archive is corrupt')
-
-            except ValueError:
+            except (CorruptZipFile, ValueError):
                 messages.error(request, 'The archive is corrupt')
 
             except BadZipFile:


### PR DESCRIPTION
If the archive is edited manually (i.e. changing a character using a text editor) it will make testZip() raise the error `ValueError` because it is unable to read the file properly.