### PR TITLE
Select backend

### DIFF
--- a/interface/backend/submission/evaluator/vmck.py
+++ b/interface/backend/submission/evaluator/vmck.py
@@ -38,7 +38,7 @@ class VMCK(Evaluator):
         name = f"{submission.assignment.full_code} submission #{submission.pk}"
         options["name"] = name
         options["restrict_network"] = True
-        options["backend"] = "raw_qemu"
+        options["backend"] = settings.EVALUATOR_BACKEND
 
         options["manager"] = {}
         options["manager"]["vagrant_tag"] = settings.MANAGER_TAG

--- a/interface/backend/submission/evaluator/vmck.py
+++ b/interface/backend/submission/evaluator/vmck.py
@@ -38,6 +38,7 @@ class VMCK(Evaluator):
         name = f"{submission.assignment.full_code} submission #{submission.pk}"
         options["name"] = name
         options["restrict_network"] = True
+        options["backend"] = "raw_qemu"
 
         options["manager"] = {}
         options["manager"]["vagrant_tag"] = settings.MANAGER_TAG

--- a/interface/settings.py
+++ b/interface/settings.py
@@ -120,6 +120,8 @@ STATIC_ROOT = os.path.join(BASE_DIR, "interface/static")
 
 SECRET_KEY = "changeme"
 
+EVALUATOR_BACKEND = os.get.get("EVALUATOR_BACKEND", "docker")
+
 DEBUG = is_true(os.environ.get("DEBUG"))
 
 _hostname = os.environ.get("HOSTNAME")

--- a/interface/settings.py
+++ b/interface/settings.py
@@ -120,7 +120,7 @@ STATIC_ROOT = os.path.join(BASE_DIR, "interface/static")
 
 SECRET_KEY = "changeme"
 
-EVALUATOR_BACKEND = os.get.get("EVALUATOR_BACKEND", "docker")
+EVALUATOR_BACKEND = os.environ.get("EVALUATOR_BACKEND", "docker")
 
 DEBUG = is_true(os.environ.get("DEBUG"))
 


### PR DESCRIPTION
## Description
Acs-interface should make requests to vmck that use the `raw_qemu` backend, while vmck's default is `qemu`, as to still have the CI working.

## Testing
- CI passes

## Checklist
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/vmck/acs-interface/labels)
- [x] Tests (if they apply)
