### PR TITLE
Removed f-string formatting without variables and in logging functions

### DIFF
--- a/interface/backend/submission/evaluator/vmck.py
+++ b/interface/backend/submission/evaluator/vmck.py
@@ -52,14 +52,14 @@ class VMCK(Evaluator):
             settings.ACS_INTERFACE_ADDRESS, callback,
         )
 
-        log.debug(f"Submission #{submission.pk} config is done")
-        log.debug(f"Callback: {options['env']['VMCK_CALLBACK_URL']}")
+        log.debug("Submission #%s config is done", submission.pk)
+        log.debug("Callback: %s", options["env"]["VMCK_CALLBACK_URL"])
 
         response = requests.post(
             urljoin(settings.VMCK_API_URL, "jobs"), json=options
         )
 
-        log.debug(f"Submission's #{submission.pk} VMCK response:\n{response}")
+        log.debug("Submission's #%s VMCK response:\n%s", submission.pk, response)
 
         return response.json()["id"]
 

--- a/interface/backend/submission/submission.py
+++ b/interface/backend/submission/submission.py
@@ -17,7 +17,7 @@ class CorruptZipFile(Exception):
 
 
 def handle_submission(file, assignment, user):
-    log.debug(f"Submission %s received", file.name)
+    log.debug("Submission %s received", file.name)
 
     test_file = deepcopy(file)
 

--- a/interface/backend/submission/submission.py
+++ b/interface/backend/submission/submission.py
@@ -17,7 +17,7 @@ class CorruptZipFile(Exception):
 
 
 def handle_submission(file, assignment, user):
-    log.debug(f"Submission {file.name} received")
+    log.debug(f"Submission %s received", file.name)
 
     test_file = deepcopy(file)
 
@@ -42,7 +42,7 @@ def handle_submission(file, assignment, user):
         if entry:
             delta_t = timezone.now() - entry.timestamp
             if delta_t.seconds < assignment.min_time_between_uploads:
-                log.debug(f"Submission can be made after #{delta_t} seconds")
+                log.debug("Submission can be made after #%s seconds", delta_t)
                 raise TooManySubmissionsError(
                     assignment.min_time_between_uploads
                 )
@@ -51,10 +51,10 @@ def handle_submission(file, assignment, user):
             user=user, archive_size=file.size,
         )
 
-    log.debug(f"Submission #{submission.pk} created")
+    log.debug("Submission #%s created", submission.pk)
 
     storage.upload(f"{submission.pk}.zip", file.read())
-    log.debug(f"Submission's #{submission.pk} zipfile was uploaded")
+    log.debug("Submission's #%s zipfile was uploaded", submission.pk)
 
     submission.evaluate()
     log.debug(

--- a/interface/backend/submission/submission_scheduler.py
+++ b/interface/backend/submission/submission_scheduler.py
@@ -40,12 +40,12 @@ class SubQueue(object):
 
             for submission in submissions:
                 submission.update_state()
-                log.info(f"Check submission #{submission.id} status")
+                log.info("Check submission #%s status", submission.id)
 
             time.sleep(settings.CHECK_INTERVAL_SUBS)
 
     def add_sub(self, sub):
-        log.info(f"Add submission #{sub.id} to queue")
+        log.info("Add submission #%s to queue", sub.id)
         sub.state = sub.STATE_QUEUED
         sub.save()
         self.queue.put((sub.timestamp, sub))
@@ -54,7 +54,7 @@ class SubQueue(object):
         self.sem.release()
 
     def _evaluate_submission(self, sub):
-        log.info(f"Evaluate submission #{sub.id}")
+        log.info("Evaluate submission #%s", sub.id)
         sub.evaluator_job_id = SubmissionScheduler.evaluator.evaluate(sub)
         sub.state = sub.STATE_NEW
         sub.changeReason = "Evaluator id"

--- a/interface/forms.py
+++ b/interface/forms.py
@@ -14,7 +14,7 @@ class UploadFileForm(forms.Form):
 
         if data.size >= settings.FILE_UPLOAD_MAX_MEMORY_SIZE:
             raise forms.ValidationError(
-                f"Keep files below "
+                "Keep files below "
                 f"{filesizeformat(settings.FILE_UPLOAD_MAX_MEMORY_SIZE)}"
             )
 

--- a/interface/views.py
+++ b/interface/views.py
@@ -49,7 +49,7 @@ def login_view(request):
             user = authenticate(username=username, password=password)
 
             if not user:
-                log.info(f"Login failure for {username}")
+                log.info("Login failure for %s", username)
             else:
                 login(request, user)
                 return redirect(homepage)
@@ -229,7 +229,7 @@ def submission_result(request, pk):
 
 @csrf_exempt
 def done(request, pk):
-    log.debug(f"URL: {request.get_full_path()}")
+    log.debug("URL: %s", request.get_full_path())
     log.debug(pprint.pformat(request.body))
 
     options = json.loads(request.body, strict=False) if request.body else {}
@@ -254,9 +254,9 @@ def done(request, pk):
     submission.stdout = stdout
     submission.update_state()
 
-    log.debug(f"Submission #{submission.pk}:")
-    log.debug(f"Stdout:\n{submission.stdout}")
-    log.debug(f"Exit code:\n{exit_code}")
+    log.debug("Submission #%s:", submission.pk)
+    log.debug("Stdout:\n%s", submission.stdout)
+    log.debug("Exit code:\n%s", exit_code)
 
     submission.changeReason = "Evaluation"
     submission.save()
@@ -313,7 +313,7 @@ def subs_for_user(request, course_pk, assignment_pk, username):
 def user_page(request, username):
     user = get_object_or_404(User, username=username)
     if request.user.username != username:
-        log.warning(f"User attempted to access {username}")
+        log.warning("User attempted to access %s", username)
         raise Http404("You are not allowed to access this page.")
     submissions = (
         Submission.objects.all().filter(user=user).order_by("-timestamp")

--- a/testsuite/test_ta_workflow.py
+++ b/testsuite/test_ta_workflow.py
@@ -172,7 +172,7 @@ def test_ta_add_new_assignment(STC, client, base_db_setup):
         "value": "Save",
     }
     response = client.post(
-        f"/admin/interface/assignment/add/", data=assignment_params,
+        "/admin/interface/assignment/add/", data=assignment_params,
     )
 
     STC.assertRedirects(
@@ -217,7 +217,7 @@ def test_ta_cannot_add_new_assignment(STC, client, base_db_setup):
         "value": "Save",
     }
     response = client.post(
-        f"/admin/interface/assignment/add/", data=assignment_params,
+        "/admin/interface/assignment/add/", data=assignment_params,
     )
 
     errors = response.context["errors"]
@@ -663,7 +663,7 @@ def test_ta_download_last_sub(client, base_db_setup, mock_admin_assignment):
     client.login(username=ta.username, password="pw")
 
     response = client.post(
-        f"/admin/interface/assignment/",
+        "/admin/interface/assignment/",
         data={
             "action": "download_review_submissions",
             "_selected_action": "1",
@@ -687,7 +687,7 @@ def test_ta_download_all_subs(client, base_db_setup, mock_admin_assignment):
     client.login(username=ta.username, password="pw")
 
     response = client.post(
-        f"/admin/interface/assignment/",
+        "/admin/interface/assignment/",
         data={"action": "download_all_submissions", "_selected_action": "1"},
         follow=True,
     )
@@ -707,7 +707,7 @@ def test_ta_run_moss(client, base_db_setup, mock_admin_assignment):
     client.login(username=ta.username, password="pw")
 
     response = client.post(
-        f"/admin/interface/assignment/",
+        "/admin/interface/assignment/",
         data={"action": "run_moss", "_selected_action": "1"},
         follow=True,
     )

--- a/testsuite/test_views.py
+++ b/testsuite/test_views.py
@@ -28,7 +28,7 @@ def test_homepage(client, STC, base_db_setup):
     (_, _, user, course, assignment) = base_db_setup
     client.login(username=user.username, password="pw")
 
-    response = client.get(f"/homepage/")
+    response = client.get("/homepage/")
 
     STC.assertTemplateUsed(response, "interface/homepage.html")
     assert response.context["courses"]


### PR DESCRIPTION
## Description
- Removed f-string formatting when no variables are used. I.E `f"My cool string!"` -> `"My cool string!"`
- Removed f-string formatting in logging functions. I.E `log.info(f"I have {apples} apples.")` -> `log.info("I have %s apples.", apples)`
  - *Note:* Used `%s` even with presence of `int`s because of specification in Issue #261 

Fixes Issues #261 and #264 
