### PR TITLE
Recomputes total score when the soft deadline changes

### DIFF
--- a/interface/admin.py
+++ b/interface/admin.py
@@ -188,6 +188,12 @@ class AssignmentAdmin(simple_history.admin.SimpleHistoryAdmin):
         "Download all submissions for review"
     )
 
+    def save_model(self, request, obj, form, change):
+        super().save_model(request, obj, form, change)
+        if "deadline_soft" not in form.changed_data:
+            return
+        obj.refresh_submission_penalty()
+
 
 @admin.register(Submission)
 class SubmissionAdmin(simple_history.admin.SimpleHistoryAdmin):

--- a/interface/models.py
+++ b/interface/models.py
@@ -94,7 +94,11 @@ class Assignment(models.Model):
         branch = self.repo_branch or "master"
         path = f"{self.repo_path}/" if self.repo_path else ""
         return urljoin(url_base, f"{branch}/{path}{filename}")
-
+    
+    def refresh_submission_penalty(self):
+        for submission in self.submission_set.all():
+            submission.penalty = None
+            submission.save()
 
 class Submission(models.Model):
     """ Model for a homework submission

--- a/testsuite/test_student_workflow.py
+++ b/testsuite/test_student_workflow.py
@@ -1,11 +1,9 @@
 import time
 import filecmp
 import zipfile
-import threading
 from io import BytesIO
 
 from tempfile import NamedTemporaryFile
-from http.server import HTTPServer, SimpleHTTPRequestHandler
 
 import pytest
 from django.conf import settings
@@ -17,33 +15,6 @@ from interface.models import Submission, Assignment
 
 
 FILEPATH = settings.BASE_DIR / "testsuite" / "test.zip"
-
-
-@pytest.fixture
-def mock_config(monkeypatch):
-    ADDR = "10.66.60.1"
-    PORT = 5000
-
-    class Server:
-        def __init__(self):
-            self.server = HTTPServer((ADDR, PORT), SimpleHTTPRequestHandler,)
-
-        def start_server(self):
-            thread = threading.Thread(
-                target=self.server.serve_forever, daemon=True,
-            )
-            thread.start()
-
-        def stop_server(self):
-            self.server.shutdown()
-            self.server.server_close()
-
-    def url_for(self, filename):
-        return f"http://{ADDR}:{PORT}/testsuite/{filename}"
-
-    monkeypatch.setattr(Assignment, "url_for", url_for)
-
-    return Server()
 
 
 @pytest.mark.django_db

--- a/testsuite/test_ta_workflow.py
+++ b/testsuite/test_ta_workflow.py
@@ -311,6 +311,8 @@ def test_soft_deadline_change_trigger_recompute(client, base_db_setup, mock_conf
 
     submission.refresh_from_db()
     assert submission.penalty == 7
+    assert submission.total_score == submission.score - submission.penalty 
+    assert submission.total_score == 93
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## Description
Adds a change on the admin site to recompute the submissions when the soft deadline changes.

Fixes #181 

## Testing
Check the included test.

## Checklist
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/vmck/acs-interface/labels)
- [x] Tests (if they apply)
