### PR TITLE
Keep waitqueue in memory

### DIFF
--- a/interface/backend/submission/submission_scheduler.py
+++ b/interface/backend/submission/submission_scheduler.py
@@ -2,7 +2,6 @@ import time
 import logging
 from queue import PriorityQueue
 from threading import BoundedSemaphore, Thread, Lock
-from copy import deepcopy
 
 from django.conf import settings
 
@@ -38,7 +37,7 @@ class SubQueue(object):
         while True:
 
             with self.subs_lock:
-                copy_submissions = deepcopy(self.subs)
+                copy_submissions = set(self.subs)
 
             log.info("Check submissions %s", len(copy_submissions))
 

--- a/interface/models.py
+++ b/interface/models.py
@@ -209,7 +209,7 @@ class Submission(models.Model):
             self.save()
 
             if self.state in [self.STATE_DONE, self.STATE_ERROR]:
-                SubmissionScheduler.get_instance().done_evaluation()
+                SubmissionScheduler.get_instance().done_evaluation(self)
 
     def download(self, buff):
         storage.download_buffer(f"{self.pk}.zip", buff)


### PR DESCRIPTION
## Description
Add an in-memory submission sent set such that if we have more instances each instance would check the submissions they have sent.

## Testing
- The tests should pass

## Checklist
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/vmck/acs-interface/labels)
- [x] Tests (if they apply)
