### PR TITLE
Ignore Moss for testing suite

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,2 @@
+ignore:
+  - "interface/moss.py" # For the moment we can not automatically test the Moss Checker


### PR DESCRIPTION
## Description
Ignore the ```moss.py``` file for codecov

## Testing
- Codecov should pass

## Checklist
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/vmck/acs-interface/labels)
- [x] Tests (if they apply)
